### PR TITLE
Fix logger test imports and ensure deterministic handlers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    env:
+      PYTHONPATH: ${{ github.workspace }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+"""Make the repository root a Python package for import resolution."""
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test suite package initialization for relative imports."""
+

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 """Tests unitarios para logger.py"""
-import pytest
 import os
-import tempfile
-import shutil
+import sys
 import logging
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 from logger import OptimizerLogger, get_logger
 
 
@@ -13,15 +21,24 @@ class TestOptimizerLogger:
     
     def setup_method(self):
         """Setup antes de cada test"""
+        self.logger_name = "TestLogger"
+        existing_logger = logging.getLogger(self.logger_name)
+        for handler in list(existing_logger.handlers):
+            existing_logger.removeHandler(handler)
+            handler.close()
         self.test_log_dir = tempfile.mkdtemp()
         self.logger = OptimizerLogger(
-            name="TestLogger",
+            name=self.logger_name,
             log_dir=self.test_log_dir,
             level=logging.DEBUG
         )
-    
+
     def teardown_method(self):
         """Cleanup después de cada test"""
+        existing_logger = logging.getLogger(self.logger_name)
+        for handler in list(existing_logger.handlers):
+            existing_logger.removeHandler(handler)
+            handler.close()
         if os.path.exists(self.test_log_dir):
             shutil.rmtree(self.test_log_dir)
     


### PR DESCRIPTION
## Summary
- add package markers so the repository and tests are recognized as Python packages
- ensure GitHub Actions exposes the project root on PYTHONPATH for test runs
- update logger tests to manage path imports and reset handlers between cases to avoid reuse

## Testing
- pytest tests/test_logger.py -v

------
https://chatgpt.com/codex/tasks/task_e_690cc329caec8325bc27d2b70d0313ab