### PR TITLE
Align report dates with configured range

### DIFF
--- a/optimizer_v2.py
+++ b/optimizer_v2.py
@@ -468,6 +468,8 @@ def run_single(cfg: Config, exe_path: str, guard_sec: int, auto_close: bool, bas
         "so_run_id": run_id,
         "so_out_dir": str(common_root),
         "so_prefix": f"{run_cfg.test.symbol}_{run_cfg.test.timeframe}_{run_cfg.test.from_}_{run_cfg.test.to}",
+        "so_start_date": run_cfg.test.from_,
+        "so_end_date": run_cfg.test.to,
     }
 
     merged = dict(run_cfg.ea.inputs or {})


### PR DESCRIPTION
## Summary
- allow the MT5 reporting helper to accept configured start/end dates and prefer them when exporting the report metadata
- propagate the configured backtest range through the optimizer so the EA receives the desired start/end dates

## Testing
- python -m py_compile optimizer_v2.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cb073c3483258af5372ab785adf2)